### PR TITLE
fix: remove DB duplicates and prevent recipe duplicate saves

### DIFF
--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -93,9 +93,15 @@ export default function RecipesPage() {
     onSuccess: (data) => setGenerated(data),
   });
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   const saveMut = useMutation({
     mutationFn: (recipe: Recipe) => saveRecipe(householdId!, recipe),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['recipes', householdId] }),
+    onSuccess: () => {
+      setSaveError(null);
+      queryClient.invalidateQueries({ queryKey: ['recipes', householdId] });
+    },
+    onError: (err: Error) => setSaveError(err.message),
   });
 
   const display = generated.length > 0 ? generated : saved;
@@ -130,6 +136,14 @@ export default function RecipesPage() {
           >
             {t('common.retry')}
           </button>
+        </div>
+      )}
+
+      {/* Save error (e.g. duplicate) */}
+      {saveError && (
+        <div className="mb-4 flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <span>{saveError}</span>
+          <button onClick={() => setSaveError(null)} className="ml-4 font-bold">✕</button>
         </div>
       )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -23,8 +23,13 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
     },
   });
   if (!res.ok) {
-    const err = await res.text();
-    throw new Error(err || res.statusText);
+    const text = await res.text();
+    let message = text || res.statusText;
+    try {
+      const json = JSON.parse(text);
+      if (json.error) message = json.error;
+    } catch { /* not JSON — use raw text */ }
+    throw new Error(message);
   }
   if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;

--- a/src/KitchenAI.Api/Program.cs
+++ b/src/KitchenAI.Api/Program.cs
@@ -111,6 +111,7 @@ app.UseExceptionHandler(errorApp =>
             ValidationException => StatusCodes.Status400BadRequest,
             UnauthorizedAccessException => StatusCodes.Status401Unauthorized,
             KeyNotFoundException => StatusCodes.Status404NotFound,
+            InvalidOperationException => StatusCodes.Status409Conflict,
             RateLimitExceededException => StatusCodes.Status429TooManyRequests,
             _ => StatusCodes.Status500InternalServerError
         };

--- a/src/KitchenAI.Application/Recipes/SaveRecipeHandler.cs
+++ b/src/KitchenAI.Application/Recipes/SaveRecipeHandler.cs
@@ -3,6 +3,7 @@ using KitchenAI.Application.Persistence;
 using KitchenAI.Domain.Entities;
 using KitchenAI.Domain.Enums;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace KitchenAI.Application.Recipes;
 
@@ -13,6 +14,14 @@ public class SaveRecipeHandler(IAppDbContext db) : IRequestHandler<SaveRecipeCom
     public async Task<RecipeDto> Handle(SaveRecipeCommand request, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(request.RecipeData.Title);
+
+        // Prevent duplicates: check if a recipe with the same title already exists for this household
+        var exists = await db.Recipes.AnyAsync(
+            r => r.HouseholdId == request.HouseholdId && r.Title == request.RecipeData.Title,
+            cancellationToken);
+
+        if (exists)
+            throw new InvalidOperationException($"The recipe with \"{request.RecipeData.Title}\" is already saved.");
 
         var recipe = new Recipe
         {


### PR DESCRIPTION
- SaveRecipeHandler: check for existing recipe by title+householdId before insert, throw InvalidOperationException with message 'The recipe with <name> is already saved.'
- Program.cs: map InvalidOperationException to HTTP 409 Conflict
- Recipes.tsx: add saveError state + amber banner displaying the 409 error message
- api.ts: extract error message from JSON response body instead of returning raw JSON string